### PR TITLE
Revert unnecessary changes

### DIFF
--- a/include/clang/Driver/Driver.h
+++ b/include/clang/Driver/Driver.h
@@ -239,7 +239,7 @@ private:
   llvm::opt::DerivedArgList *
   TranslateInputArgs(const llvm::opt::InputArgList &Args) const;
 
-  // getFinalPhase - Determine which compilation mode we are in and record
+  // getFinalPhase - Determine which compilation mode we are in and record 
   // which option we used to determine the final phase.
   phases::ID getFinalPhase(const llvm::opt::DerivedArgList &DAL,
                            llvm::opt::Arg **FinalPhaseArg = nullptr) const;
@@ -347,12 +347,12 @@ public:
   /// ArgList.
   llvm::opt::InputArgList ParseArgStrings(ArrayRef<const char *> Args);
 
-  /// BuildInputs - Construct the list of inputs and their types from
+  /// BuildInputs - Construct the list of inputs and their types from 
   /// the given arguments.
   ///
   /// \param TC - The default host tool chain.
   /// \param Args - The input arguments.
-  /// \param Inputs - The list to store the resulting compilation
+  /// \param Inputs - The list to store the resulting compilation 
   /// inputs onto.
   void BuildInputs(const ToolChain &TC, llvm::opt::DerivedArgList &Args,
                    InputList &Inputs) const;
@@ -389,9 +389,9 @@ public:
   int ExecuteCompilation(Compilation &C,
      SmallVectorImpl< std::pair<int, const Command *> > &FailingCommands);
 
-  /// generateCompilationDiagnostics - Generate diagnostics information
+  /// generateCompilationDiagnostics - Generate diagnostics information 
   /// including preprocessed source file(s).
-  ///
+  /// 
   void generateCompilationDiagnostics(Compilation &C,
                                       const Command &FailingCommand);
 
@@ -461,7 +461,7 @@ public:
   /// \param JA - The action of interest.
   /// \param BaseInput - The original input file that this action was
   /// triggered by.
-  /// \param BoundArch - The bound architecture.
+  /// \param BoundArch - The bound architecture. 
   /// \param AtTopLevel - Whether this is a "top-level" action.
   /// \param MultipleArchs - Whether multiple -arch options were supplied.
   /// \param NormalizedTriple - The normalized triple of the relevant target.
@@ -470,7 +470,7 @@ public:
                                  bool AtTopLevel, bool MultipleArchs,
                                  StringRef NormalizedTriple) const;
 
-  /// GetTemporaryPath - Return the pathname of a temporary file to use
+  /// GetTemporaryPath - Return the pathname of a temporary file to use 
   /// as part of compilation; the file will have the given prefix and suffix.
   ///
   /// GCC goes to extra lengths here to be a bit more robust.

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -112,6 +112,7 @@ void Driver::setDriverModeFromOption(StringRef Opt) {
   if (!Opt.startswith(OptName))
     return;
   StringRef Value = Opt.drop_front(OptName.size());
+
   const unsigned M = llvm::StringSwitch<unsigned>(Value)
                          .Case("gcc", GCCMode)
                          .Case("g++", GXXMode)

--- a/lib/Driver/ToolChain.cpp
+++ b/lib/Driver/ToolChain.cpp
@@ -494,7 +494,7 @@ std::string ToolChain::ComputeLLVMTriple(const ArgList &Args,
     StringRef Suffix =
       tools::arm::getLLVMArchSuffixForARM(CPU, MArch, Triple);
     bool IsMProfile = ARM::parseArchProfile(Suffix) == ARM::PK_M;
-    bool ThumbDefault = IsMProfile || (ARM::parseArchVersion(Suffix) == 7 &&
+    bool ThumbDefault = IsMProfile || (ARM::parseArchVersion(Suffix) == 7 && 
                                        getTriple().isOSBinFormatMachO());
     // FIXME: this is invalid for WindowsCE
     if (getTriple().isOSWindows())


### PR DESCRIPTION
These are while-space changes relative to the upstream Clang. They're not bad, but removing unnecessary changes is likely to make future merging easier.