### PR TITLE
Fix backslash flags

### DIFF
--- a/include/clang/Driver/Options.td
+++ b/include/clang/Driver/Options.td
@@ -2220,8 +2220,10 @@ defm aggressive_function_elimination : BooleanFFlag<"aggressive-function-elimina
 defm align_commons : BooleanFFlag<"align-commons">, Group<gfortran_Group>;
 defm all_intrinsics : BooleanFFlag<"all-intrinsics">, Group<gfortran_Group>;
 defm automatic : BooleanFFlag<"automatic">, Group<gfortran_Group>;
-defm backslash : BooleanFFlag<"backslash">, Group<gfortran_Group>,
+def fbackslash: Flag<["-"], "fbackslash">, Group<gfortran_Group>,
   HelpText<"Treat backslash as C-style escape character">;
+def fnobackslash: Flag<["-"], "fno-backslash">, Group<gfortran_Group>,
+  HelpText<"Treat backslash like any other character in character strings">;
 defm backtrace : BooleanFFlag<"backtrace">, Group<gfortran_Group>;
 defm bounds_check : BooleanFFlag<"bounds-check">, Group<gfortran_Group>;
 defm check_array_temporaries : BooleanFFlag<"check-array-temporaries">, Group<gfortran_Group>;
@@ -2334,8 +2336,10 @@ def Mbyteswapio: Flag<["-"], "Mbyteswapio">, Group<gfortran_Group>,
   HelpText<"Swap byte-order for unformatted input/output">;
 def byteswapio: Flag<["-"], "byteswapio">, Group<gfortran_Group>,
   HelpText<"Swap byte-order for unformatted input/output">;
-defm Mbackslash: BooleanMFlag<"backslash">, Group<gfortran_Group>,
+def Mbackslash: Flag<["-"], "Mbackslash">, Group<gfortran_Group>, Alias<fnobackslash>,
   HelpText<"Treat backslash like any other character in character strings">;
+def Mnobackslash: Flag<["-"], "Mnobackslash">, Group<gfortran_Group>, Alias<fbackslash>,
+  HelpText<"Treat backslash as C-style escape character">;
 def staticFlangLibs: Flag<["-"], "static-flang-libs">, Group<gfortran_Group>,
   HelpText<"Link using static Flang libraries">;
 def noFlangLibs: Flag<["-"], "no-flang-libs">, Group<gfortran_Group>,

--- a/lib/Driver/Tools.cpp
+++ b/lib/Driver/Tools.cpp
@@ -4016,20 +4016,20 @@ void FlangFrontend::ConstructJob(Compilation &C, const JobAction &JA,
     CommonCmdArgs.push_back("2");
   }
 
-  // Treat backslashes as escape characters, just like C does
-  for (auto Arg : Args.filtered(options::OPT_Mbackslash_on, options::OPT_backslash_fno)) {
+  // Treat backslashes as regular characters
+  for (auto Arg : Args.filtered(options::OPT_fnobackslash)) {
     Arg->claim();
     CommonCmdArgs.push_back("-x");
     CommonCmdArgs.push_back("124");
-    CommonCmdArgs.push_back("0x4");
+    CommonCmdArgs.push_back("0x40");
   }
 
-  // Treat backslashes as regular characters
-  for (auto Arg : Args.filtered(options::OPT_Mbackslash_off, options::OPT_backslash_f)) {
+  // Treat backslashes as C-style escape characters
+  for (auto Arg : Args.filtered(options::OPT_fbackslash)) {
     Arg->claim();
     CommonCmdArgs.push_back("-y");
     CommonCmdArgs.push_back("124");
-    CommonCmdArgs.push_back("0x4");
+    CommonCmdArgs.push_back("0x40");
   }
 
   // handle OpemMP options


### PR DESCRIPTION
-f[no-]backslash and -M[no]backslash did not affect compilation of a program
with a backslash in a string literal, as described in flang-compiler/flang#42

Also, clean up backslash flags' descriptions in -help output, to give "no"
flags a description different from their respective -f/-M counterparts.