### PR TITLE
Disable setting default optimization level to 1

### DIFF
--- a/lib/Driver/Tools.cpp
+++ b/lib/Driver/Tools.cpp
@@ -4642,10 +4642,6 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   CmdArgs.push_back("-triple");
   CmdArgs.push_back(Args.MakeArgString(TripleStr));
 
-  // For FLANG, we want to pass -O1 as the default, iff no -O was given
-  if (IsFlang && (!Args.getLastArg(options::OPT_O_Group)))
-      CmdArgs.push_back("-O1");
-
   if (IsCuda) {
     // We have to pass the triple of the host if compiling for a CUDA device and
     // vice-versa.


### PR DESCRIPTION
We used to set -O1 for the optimizer if user did not specify anything.
Fix for #9