### PR TITLE
Fix descriptions of "default real" and "default integer" flags

### DIFF
--- a/include/clang/Driver/Options.td
+++ b/include/clang/Driver/Options.td
@@ -2369,10 +2369,14 @@ defm cray_pointer : BooleanFFlag<"cray-pointer">, Group<gfortran_Group>;
 defm d_lines_as_code : BooleanFFlag<"d-lines-as-code">, Group<gfortran_Group>;
 defm d_lines_as_comments : BooleanFFlag<"d-lines-as-comments">, Group<gfortran_Group>;
 defm default_double_8 : BooleanFFlag<"default-double-8">, Group<gfortran_Group>;
-defm default_integer_8 : BooleanFFlag<"default-integer-8">, Group<gfortran_Group>,
+def f_default_integer_8: Flag<["-"], "fdefault-integer-8">, Group<gfortran_Group>,
   HelpText<"Treat INTEGER and LOGICAL as INTEGER*8 and LOGICAL*8">;
-defm default_real_8 : BooleanFFlag<"default-real-8">, Group<gfortran_Group>,
+def fno_default_integer_8: Flag<["-"], "fno-default-integer-8">, Group<gfortran_Group>,
+  HelpText<"Disable treating INTEGER and LOGICAL as INTEGER*8 and LOGICAL*8">;
+def f_default_real_8: Flag<["-"], "fdefault-real-8">, Group<gfortran_Group>,
   HelpText<"Treat REAL as REAL*8">;
+def fno_default_real_8: Flag<["-"], "fno-default-real-8">, Group<gfortran_Group>,
+  HelpText<"Disable treating REAL as REAL*8">;
 defm dollar_ok : BooleanFFlag<"dollar-ok">, Group<gfortran_Group>;
 defm dump_fortran_optimized : BooleanFFlag<"dump-fortran-optimized">, Group<gfortran_Group>;
 defm dump_fortran_original : BooleanFFlag<"dump-fortran-original">, Group<gfortran_Group>;
@@ -2483,10 +2487,10 @@ def staticFlangLibs: Flag<["-"], "static-flang-libs">, Group<gfortran_Group>,
 def noFlangLibs: Flag<["-"], "no-flang-libs">, Group<gfortran_Group>,
   HelpText<"Do not link against Flang libraries">;
 def r8: Flag<["-"], "r8">, Group<gfortran_Group>,
-  Alias<default_real_8_f>,
+  Alias<f_default_real_8>,
   HelpText<"Treat REAL as REAL*8">;
 def i8: Flag<["-"], "i8">, Group<gfortran_Group>,
-  Alias<default_integer_8_f>,
+  Alias<f_default_integer_8>,
   HelpText<"Treat INTEGER and LOGICAL as INTEGER*8 and LOGICAL*8">;
 def no_fortran_main: Flag<["-"], "fno-fortran-main">, Group<gfortran_Group>,
   HelpText<"Don't link in Fortran main">;

--- a/lib/Driver/Tools.cpp
+++ b/lib/Driver/Tools.cpp
@@ -4387,18 +4387,18 @@ void FlangFrontend::ConstructJob(Compilation &C, const JobAction &JA,
   }
 
   // Handle -fdefault-real-8 (and its alias, -r8) and -fno-default-real-8
-  if (Arg *A = Args.getLastArg(options::OPT_default_real_8_f,
-                               options::OPT_default_real_8_fno)) {
+  if (Arg *A = Args.getLastArg(options::OPT_f_default_real_8,
+                               options::OPT_fno_default_real_8)) {
     const char * fl;
     // For -f version add -x flag, for -fno add -y
-    if (A->getOption().matches(options::OPT_default_real_8_f)) {
+    if (A->getOption().matches(options::OPT_f_default_real_8)) {
       fl = "-x";
     } else {
       fl = "-y";
     }
 
-    for (Arg *A : Args.filtered(options::OPT_default_real_8_f,
-                                options::OPT_default_real_8_fno)) {
+    for (Arg *A : Args.filtered(options::OPT_f_default_real_8,
+                                options::OPT_fno_default_real_8)) {
       A->claim();
     }
 
@@ -4411,11 +4411,11 @@ void FlangFrontend::ConstructJob(Compilation &C, const JobAction &JA,
   }
 
   // Process and claim -i8/-fdefault-integer-8/-fno-default-integer-8 argument
-  if (Arg *A = Args.getLastArg(options::OPT_default_integer_8_f,
-                               options::OPT_default_integer_8_fno)) {
+  if (Arg *A = Args.getLastArg(options::OPT_f_default_integer_8,
+                               options::OPT_fno_default_integer_8)) {
     const char * fl;
 
-    if (A->getOption().matches(options::OPT_default_integer_8_f)) {
+    if (A->getOption().matches(options::OPT_f_default_integer_8)) {
       fl = "-x";
     } else {
       fl = "-y";


### PR DESCRIPTION
Split flag definitions in two to have to separate messages and fix "no"
variants.