### PR TITLE
Implement support for -ffixed-line-length-<value>

### DIFF
--- a/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/include/clang/Basic/DiagnosticDriverKinds.td
@@ -44,6 +44,8 @@ def err_drv_invalid_rtlib_name : Error<
   "invalid runtime library name in argument '%0'">;
 def err_drv_invalid_allocatable_mode : Error<
   "invalid semantic mode for assignments to allocatables in argument '%0'">;
+def err_drv_unsupported_fixed_line_length : Error<
+  "unsupported fixed-format line length in argument '%0'">;
 def err_drv_unsupported_rtlib_for_platform : Error<
   "unsupported runtime library '%0' for platform '%1'">;
 def err_drv_invalid_stdlib_name : Error<

--- a/include/clang/Driver/Options.td
+++ b/include/clang/Driver/Options.td
@@ -2340,7 +2340,8 @@ def fblas_matmul_limit_EQ : Joined<["-"], "fblas-matmul-limit=">, Group<gfortran
 def fcheck_EQ : Joined<["-"], "fcheck=">, Group<gfortran_Group>;
 def fcoarray_EQ : Joined<["-"], "fcoarray=">, Group<gfortran_Group>;
 def fconvert_EQ : Joined<["-"], "fconvert=">, Group<gfortran_Group>;
-def ffixed_line_length_VALUE : Joined<["-"], "ffixed-line-length-">, Group<gfortran_Group>;
+def ffixed_line_length_VALUE : Joined<["-"], "ffixed-line-length-">, Group<gfortran_Group>,
+  HelpText<"Set line length in fixed-form format Fortran, current supporting only 72 and 132 characters">;
 def ffpe_trap_EQ : Joined<["-"], "ffpe-trap=">, Group<gfortran_Group>;
 def ffree_line_length_VALUE : Joined<["-"], "ffree-line-length-">, Group<gfortran_Group>;
 def finit_character_EQ : Joined<["-"], "finit-character=">, Group<gfortran_Group>;

--- a/lib/Driver/Tools.cpp
+++ b/lib/Driver/Tools.cpp
@@ -4727,6 +4727,19 @@ void FlangFrontend::ConstructJob(Compilation &C, const JobAction &JA,
     UpperCmdArgs.push_back("-extend");
   }
 
+  for (auto Arg : Args.filtered(options::OPT_ffixed_line_length_VALUE)) {
+    StringRef Value = Arg->getValue();
+    if (Value == "72") {
+      Arg->claim();
+    } else if (Value == "132") {
+      Arg->claim();
+      UpperCmdArgs.push_back("-extend");
+    } else {
+      getToolChain().getDriver().Diag(diag::err_drv_unsupported_fixed_line_length)
+        << Arg->getAsString(Args);
+    }
+  }
+
   // Add user-defined include directories
   for (auto Arg : Args.filtered(options::OPT_I)) {
     Arg->claim();


### PR DESCRIPTION
Parse -ffixed-line-length-<value> argument, value=72 is the same as default,
value=132 is the same as -Mextend, other values are unsupported (result in
error).
