### PR TITLE
Add Windows support

### DIFF
--- a/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/lib/Driver/ToolChains/CommonArgs.cpp
@@ -67,7 +67,7 @@ bool tools::needFortranLibs(const Driver &D, const ArgList &Args) {
 }
 
 /// \brief Determine if Fortran "main" object is needed
-static bool needFortranMain(const Driver &D, const ArgList &Args) {
+bool tools::needFortranMain(const Driver &D, const ArgList &Args) {
   return (needFortranLibs(D, Args)
        && (!Args.hasArg(options::OPT_Mnomain) ||
            !Args.hasArg(options::OPT_no_fortran_main)));

--- a/lib/Driver/ToolChains/CommonArgs.h
+++ b/lib/Driver/ToolChains/CommonArgs.h
@@ -22,6 +22,8 @@ namespace tools {
 
 bool needFortranLibs(const Driver &D, const llvm::opt::ArgList &Args);
 
+bool needFortranMain(const Driver &D, const llvm::opt::ArgList &Args);
+
 void addPathIfExists(const Driver &D, const Twine &Path,
                      ToolChain::path_list &Paths);
 

--- a/lib/Driver/ToolChains/MSVC.h
+++ b/lib/Driver/ToolChains/MSVC.h
@@ -106,6 +106,9 @@ public:
       const llvm::opt::ArgList &DriverArgs,
       llvm::opt::ArgStringList &CC1Args) const override;
 
+  void AddFortranStdlibLibArgs(const llvm::opt::ArgList &DriverArgs,
+                               llvm::opt::ArgStringList &CC1Args) const override;
+
   void AddCudaIncludeArgs(const llvm::opt::ArgList &DriverArgs,
                           llvm::opt::ArgStringList &CC1Args) const override;
 


### PR DESCRIPTION
These are changes to add the correct linker flags when flang is used on windows, where the linker step falls back to calling link.exe.

These changes are intended to work in combination with the changes in flang-compiler/flang#288.