### PR TITLE
Guard hardcoded defines with cpp.

### DIFF
--- a/lib/Driver/ToolChains/Flang.cpp
+++ b/lib/Driver/ToolChains/Flang.cpp
@@ -572,12 +572,20 @@ void FlangFrontend::ConstructJob(Compilation &C, const JobAction &JA,
   // Add system include arguments.
   getToolChain().AddFlangSystemIncludeArgs(Args, UpperCmdArgs);
 
+#if defined(unix) || defined(__unix) || defined(__unix__)
   UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("unix");
   UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__unix");
   UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__unix__");
+#endif
+#if defined(linux) || defined(__linux) || defined(__linux__)
   UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("linux");
   UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__linux");
   UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__linux__");
+#elif defined(__FreeBSD__)
+  UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__FreeBSD__");
+#elif defined(__OpenBSD__)
+  UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__OpenBSD__");
+#endif
   UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__NO_MATH_INLINES");
   UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__LP64__");
   UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__x86_64");


### PR DESCRIPTION
Hello, 

Not sure this should really be defined here as it encourage to rely on non standard fortran preprocessing, but at least, but such defines should at least be guarded to avoid wrong declaration? Adding Free/OpenBSD while I'm at it...

Would it be useful to also declare __flang__ __flang_major/minor/patch__ based on corresponding clang variable?

Thanks for your work!