### PR TITLE
Our approach to issue #6

### DIFF
--- a/lib/Driver/ToolChains/Flang.cpp
+++ b/lib/Driver/ToolChains/Flang.cpp
@@ -585,17 +585,36 @@ void FlangFrontend::ConstructJob(Compilation &C, const JobAction &JA,
   UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__linux");
   UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__linux__");
   UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__NO_MATH_INLINES");
-  UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__LP64__");
-  UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__x86_64");
-  UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__x86_64__");
-  UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__LONG_MAX__=9223372036854775807L");
-  UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__SIZE_TYPE__=unsigned long int");
-  UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__PTRDIFF_TYPE__=long int");
+  switch (getToolChain().getEffectiveTriple().getArch()) {
+  case llvm::Triple::aarch64:
+    UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__LP64__");
+    UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__aarch64");
+    UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__aarch64__");
+    UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__ARM_ARCH=8");
+    UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__ARM_ARCH__=8");
+    UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__LONG_MAX__=9223372036854775807L");
+    UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__SIZE_TYPE__=unsigned long int");
+    UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__PTRDIFF_TYPE__=long int");
+    break;
+  case llvm::Triple::x86_64:
+    UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__LP64__");
+    UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__x86_64");
+    UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__x86_64__");
+    UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__amd_64__amd64__");
+    UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__k8");
+    UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__k8__");
+    UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__LONG_MAX__=9223372036854775807L");
+    UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__SIZE_TYPE__=unsigned long int");
+    UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__PTRDIFF_TYPE__=long int");
+    break;
+  default: /* generic 64-bit */
+    UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__LP64__");
+    UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__LONG_MAX__=9223372036854775807L");
+    UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__SIZE_TYPE__=unsigned long int");
+    UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__PTRDIFF_TYPE__=long int");
+  }
   UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__THROW=");
   UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__extension__=");
-  UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__amd_64__amd64__");
-  UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__k8");
-  UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__k8__");
   UpperCmdArgs.push_back("-def"); UpperCmdArgs.push_back("__PGLLVM__");
 
   // Enable preprocessor

--- a/test/Driver/arch-specific-macros.f
+++ b/test/Driver/arch-specific-macros.f
@@ -1,0 +1,15 @@
+! RUN: %flang -target aarch64 -v -x f77 -### -c - 2>&1 >/dev/null | FileCheck --check-prefix=AARCH64 %s
+! RUN: %flang -target x86_64 -v -x f77 -### -c - 2>&1 >/dev/null | FileCheck --check-prefix=X86_64 %s
+
+! AARCH64: __aarch64__
+! AARCH64: __ARM_ARCH=8
+! AARCH64: __ARM_ARCH__=8
+! AARCH64-NOT: __x86_64__
+! AARCH64-NOT: __amd_64__amd64__
+! AARCH64-NOT: __k8__
+
+! X86_64: __x86_64__
+! X86_64: __amd_64__amd64__
+! X86_64: __k8__
+! X86_64-NOT: __aarch64__
+! X86_64-NOT: __ARM_ARCH


### PR DESCRIPTION
This defines things clang defines for ARMv8 architecture which makes it possible to consistently use preprocessor macros across languages.
